### PR TITLE
Fix Table Formatting to Override Italic Font Style Inheritance

### DIFF
--- a/Note Types/AnKing/Styling.css
+++ b/Note Types/AnKing/Styling.css
@@ -262,6 +262,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/AnKingDerm/Styling.css
+++ b/Note Types/AnKingDerm/Styling.css
@@ -277,6 +277,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/AnKingMCAT/Styling.css
+++ b/Note Types/AnKingMCAT/Styling.css
@@ -280,6 +280,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/AnKingOverhaul/Styling.css
+++ b/Note Types/AnKingOverhaul/Styling.css
@@ -316,6 +316,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/Basic-AnKing/Styling.css
+++ b/Note Types/Basic-AnKing/Styling.css
@@ -212,6 +212,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/Basic-AnKingLanguage/Styling.css
+++ b/Note Types/Basic-AnKingLanguage/Styling.css
@@ -232,6 +232,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/IO-one by one/Styling.css
+++ b/Note Types/IO-one by one/Styling.css
@@ -175,6 +175,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/Physeo-Cloze/Styling.css
+++ b/Note Types/Physeo-Cloze/Styling.css
@@ -259,6 +259,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/Physeo-IO one by one/Styling.css
+++ b/Note Types/Physeo-IO one by one/Styling.css
@@ -175,6 +175,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 

--- a/Note Types/Sketchy-Cloze/Styling.css
+++ b/Note Types/Sketchy-Cloze/Styling.css
@@ -259,6 +259,7 @@ border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
+font-style: normal;
 max-width: 95vw;
 }
 


### PR DESCRIPTION
I noticed that the tables were picking up italic styles from the extra field, which isn't ideal for a table. I've tweaked the CSS so the tables keep their normal, straightforward font style

**What I did:**
- Modified the CSS for table elements to explicitly set `font-style: normal;` ensuring it does not inherit italicization

**Why it matters:**
- Keeps the tables looking clean and easy to read

**Testing done:**
- Modified the note type in Anki desktop with this change and it worked

Let me know what you think or if there’s anything else I need to adjust