### PR TITLE
Fix Table Formatting to Override Italic Font Style Inheritance (#2)

### DIFF
--- a/src/notetypes/AnKing/Styling.css
+++ b/src/notetypes/AnKing/Styling.css
@@ -261,6 +261,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/AnKingDerm/Styling.css
+++ b/src/notetypes/AnKingDerm/Styling.css
@@ -276,6 +276,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/AnKingMCAT/Styling.css
+++ b/src/notetypes/AnKingMCAT/Styling.css
@@ -279,6 +279,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/AnKingOverhaul/Styling.css
+++ b/src/notetypes/AnKingOverhaul/Styling.css
@@ -315,6 +315,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/Basic-AnKing/Styling.css
+++ b/src/notetypes/Basic-AnKing/Styling.css
@@ -211,6 +211,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/Basic-AnKingLanguage/Styling.css
+++ b/src/notetypes/Basic-AnKingLanguage/Styling.css
@@ -231,6 +231,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/IO-one by one/Styling.css
+++ b/src/notetypes/IO-one by one/Styling.css
@@ -174,6 +174,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/Physeo-Cloze/Styling.css
+++ b/src/notetypes/Physeo-Cloze/Styling.css
@@ -258,6 +258,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/Physeo-IO one by one/Styling.css
+++ b/src/notetypes/Physeo-IO one by one/Styling.css
@@ -174,6 +174,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }

--- a/src/notetypes/Sketchy-Cloze/Styling.css
+++ b/src/notetypes/Sketchy-Cloze/Styling.css
@@ -258,6 +258,7 @@ margin-right: auto;
 border-collapse: collapse;
 overflow: scroll;
 white-space: normal;
+font-style: normal;
 font-size: clamp(0.1rem, 1.7vw, 0.9rem) !important;
 max-width: 95vw;
 }


### PR DESCRIPTION
Tweaked the CSS so tables keep their normal font style

(Take 2, last PR was to wrong files)