### PR TITLE
fix: Don't show duplicate MH resource links

### DIFF
--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingAnkisthesia/Back Template.html
+++ b/Note Types/AnKingAnkisthesia/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 

--- a/Note Types/AnKingAnkisthesia/Back Template.html
+++ b/Note Types/AnKingAnkisthesia/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 

--- a/Note Types/AnKingAnkisthesia/Front Template.html
+++ b/Note Types/AnKingAnkisthesia/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 <!-- ##############  Text-to-speech  ##############

--- a/Note Types/AnKingAnkisthesia/Front Template.html
+++ b/Note Types/AnKingAnkisthesia/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 <!-- ##############  Text-to-speech  ##############

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -466,7 +462,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // Clean path parts (remove number prefixes)
-                const cleanedPathParts = pathParts.map(part => part.replace(/\d+_/g, ''));
+                const cleanedPathParts = pathParts.map(part => part.replace(/^\d+_/g, ''));
 
                 // Create slug and title
                 const slug = `step${step}-${resourceSlug}-${cleanedPathParts.join('-')}`;
@@ -493,32 +489,35 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
         function setupTagBasedHintButton(hintButton) {
             const resourceTags = getResourceTags(tags, hintButton.dataset.resourceTypeTagPart);
-            if (resourceTags && resourceTags.length > 0) {
-                const button = document.getElementById(hintButton.id);
-                const hintsDiv = button.querySelector('.hints');
+            if (!resourceTags || resourceTags.length == 0) {
+                return;
+            }
 
-                button.classList.remove('hidden');
+            const button = document.getElementById(hintButton.id);
+            const hintsDiv = button.querySelector('.hints');
 
-                // Process tags and create links
-                const resourceLinks = resourceTags
-                    .map(tag => {
-                        const resource = tagToResourceTitleAndSlug(tag, hintButton.dataset.resourceSlug);
-                        if (resource) {
-                            const url = createResourceUrl(resource.slug);
-                            return `<a href="${url}" target="_blank">${hintButton.dataset.linkPrefix}${resource.title}</a>`;
-                        }
-                        return null;
-                    })
-                    .filter(link => link !== null);
+            // Create links from the resource tags
+            const resourceLinks = resourceTags
+                .map(tag => {
+                    const resource = tagToResourceTitleAndSlug(tag, hintButton.dataset.resourceSlug);
+                    if (resource) {
+                        const url = createResourceUrl(resource.slug);
+                        return `<a href="${url}" target="_blank">${hintButton.dataset.linkPrefix}${resource.title}</a>`;
+                    }
+                    return null;
+                })
+                .filter(link => link !== null);
 
-                // Remove duplicates
-                const uniqueResourceLinks = [...new Set(resourceLinks)];
+            // Remove duplicates
+            const uniqueResourceLinks = [...new Set(resourceLinks)];
 
-                // Sort by title
-                uniqueResourceLinks.sort((a, b) => a.localeCompare(b));
+            // Sort by title
+            uniqueResourceLinks.sort((a, b) => a.localeCompare(b));
 
+            // Update button visibility and content
+            if (uniqueResourceLinks.length > 0) {
                 hintsDiv.innerHTML = uniqueResourceLinks.join('<br>');
-
+                button.classList.remove('hidden');
             }
         }
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -448,6 +448,19 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 let pathParts = path.split('::');
                 pathParts = pathParts.map(part => part.toLowerCase());
 
+                // Remove path parts after first path part starting with "*"
+                for (let index = 0; index < pathParts.length; index++) {
+                    if (pathParts[index].startsWith("*")) {
+                        pathParts = pathParts.slice(0, index);
+                        break;
+                    }
+                }
+
+                // Remove the last part if it is "extra"
+                if (pathParts[pathParts.length - 1] === "extra") {
+                    pathParts = pathParts.slice(0, -1);
+                }
+
                 // Clean path parts (remove number prefixes)
                 const cleanedPathParts = pathParts.map(part => part.replace(/\d+_/g, ''));
 
@@ -483,7 +496,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 button.classList.remove('hidden');
 
                 // Process tags and create links
-                const processedResources = resourceTags
+                const resourceLinks = resourceTags
                     .map(tag => {
                         const resource = tagToResourceTitleAndSlug(tag, hintButton.dataset.resourceSlug);
                         if (resource) {
@@ -493,7 +506,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                         return null;
                     })
                     .filter(link => link !== null);
-                hintsDiv.innerHTML = processedResources.join('<br>');
+
+                // Remove duplicates
+                const uniqueResourceLinks = [...new Set(resourceLinks)];
+
+                // Sort by title
+                uniqueResourceLinks.sort((a, b) => a.localeCompare(b));
+
+                hintsDiv.innerHTML = uniqueResourceLinks.join('<br>');
 
             }
         }

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverlapping/Back Template.html
+++ b/Note Types/AnKingOverlapping/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on

--- a/Note Types/AnKingOverlapping/Back Template.html
+++ b/Note Types/AnKingOverlapping/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on

--- a/Note Types/AnKingOverlapping/Front Template.html
+++ b/Note Types/AnKingOverlapping/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverlapping/Front Template.html
+++ b/Note Types/AnKingOverlapping/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-<!-- version bb78f1b -->
-=======
-<!-- version ccbaa97 -->
->>>>>>> master
+<!-- version b169a0b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7d244ed -->
+<!-- version bb78f1b -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/src/components/tagBasedHintButtonsSetup.ejs
+++ b/src/components/tagBasedHintButtonsSetup.ejs
@@ -53,32 +53,35 @@
 
         function setupTagBasedHintButton(hintButton) {
             const resourceTags = getResourceTags(tags, hintButton.dataset.resourceTypeTagPart);
-            if (resourceTags && resourceTags.length > 0) {
-                const button = document.getElementById(hintButton.id);
-                const hintsDiv = button.querySelector('.hints');
+            if (!resourceTags || resourceTags.length == 0) {
+                return;
+            }
 
-                button.classList.remove('hidden');
+            const button = document.getElementById(hintButton.id);
+            const hintsDiv = button.querySelector('.hints');
 
-                // Process tags and create links
-                const resourceLinks = resourceTags
-                    .map(tag => {
-                        const resource = tagToResourceTitleAndSlug(tag, hintButton.dataset.resourceSlug);
-                        if (resource) {
-                            const url = createResourceUrl(resource.slug);
-                            return `<a href="${url}" target="_blank">${hintButton.dataset.linkPrefix}${resource.title}</a>`;
-                        }
-                        return null;
-                    })
-                    .filter(link => link !== null);
+            // Create links from the resource tags
+            const resourceLinks = resourceTags
+                .map(tag => {
+                    const resource = tagToResourceTitleAndSlug(tag, hintButton.dataset.resourceSlug);
+                    if (resource) {
+                        const url = createResourceUrl(resource.slug);
+                        return `<a href="${url}" target="_blank">${hintButton.dataset.linkPrefix}${resource.title}</a>`;
+                    }
+                    return null;
+                })
+                .filter(link => link !== null);
 
-                // Remove duplicates
-                const uniqueResourceLinks = [...new Set(resourceLinks)];
+            // Remove duplicates
+            const uniqueResourceLinks = [...new Set(resourceLinks)];
 
-                // Sort by title
-                uniqueResourceLinks.sort((a, b) => a.localeCompare(b));
+            // Sort by title
+            uniqueResourceLinks.sort((a, b) => a.localeCompare(b));
 
+            // Update button visibility and content
+            if (uniqueResourceLinks.length > 0) {
                 hintsDiv.innerHTML = uniqueResourceLinks.join('<br>');
-
+                button.classList.remove('hidden');
             }
         }
 

--- a/src/components/tagBasedHintButtonsSetup.ejs
+++ b/src/components/tagBasedHintButtonsSetup.ejs
@@ -60,7 +60,7 @@
                 button.classList.remove('hidden');
 
                 // Process tags and create links
-                const processedResources = resourceTags
+                const resourceLinks = resourceTags
                     .map(tag => {
                         const resource = tagToResourceTitleAndSlug(tag, hintButton.dataset.resourceSlug);
                         if (resource) {
@@ -70,7 +70,14 @@
                         return null;
                     })
                     .filter(link => link !== null);
-                hintsDiv.innerHTML = processedResources.join('<br>');
+
+                // Remove duplicates
+                const uniqueResourceLinks = [...new Set(resourceLinks)];
+
+                // Sort by title
+                uniqueResourceLinks.sort((a, b) => a.localeCompare(b));
+
+                hintsDiv.innerHTML = uniqueResourceLinks.join('<br>');
 
             }
         }

--- a/src/components/tagBasedHintButtonsSetup.ejs
+++ b/src/components/tagBasedHintButtonsSetup.ejs
@@ -26,7 +26,7 @@
                 }
 
                 // Clean path parts (remove number prefixes)
-                const cleanedPathParts = pathParts.map(part => part.replace(/\d+_/g, ''));
+                const cleanedPathParts = pathParts.map(part => part.replace(/^\d+_/g, ''));
 
                 // Create slug and title
                 const slug = `step${step}-${resourceSlug}-${cleanedPathParts.join('-')}`;


### PR DESCRIPTION
We need to prevent showing duplicate resources for a note.

If there are multiple tags that reference the same resource, there should still be just one link for the resource.

## Related issues
https://ankihub.atlassian.net/jira/software/c/projects/BUILD/boards/1?selectedIssue=BUILD-933